### PR TITLE
Docs: add error code reference

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,0 +1,15 @@
+# Error Codes Mapping
+
+When interacting with the Grant Stream smart contracts, developers might encounter generic numerical error codes (e.g., `Error(7)`). This table maps these numerical codes to human-readable reasons to help with debugging.
+
+| Error Code | Human-Readable Reason   | Description                                                                       |
+| ---------- | ----------------------- | --------------------------------------------------------------------------------- |
+| `1`        | Not Authorized          | The caller does not have the required permissions.                                |
+| `2`        | Insufficient Balance    | The account or contract does not have enough funds to complete the transaction.   |
+| `3`        | Grant Not Found         | The specified grant ID does not exist in storage.                                 |
+| `4`        | Grant Paused            | The grant has been paused by the admin or council.                                |
+| `5`        | Invalid Amount          | The specified amount is invalid (e.g., exceeds remaining balance or total grant). |
+| `6`        | Already Exists          | The resource (grant, milestone, etc.) already exists.                             |
+| `7`        | Under Dispute / Blocked | The action is blocked due to an active dispute or existing state.                 |
+
+_Note: If you encounter an error code not listed here, please verify the contract source code or Soroban SDK standard errors._

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-
 ## Deployed Contract
+
 - **Network:** Stellar Testnet
 - **Contract ID:** CD6OGC46OFCV52IJQKEDVKLX5ASA3ZMSTHAAZQIPDSJV6VZ3KUJDEP4D
 
+## Troubleshooting
+
+If you encounter generic error codes (e.g., `Error(7)`) during interaction, please refer to the [Error Codes Mapping](ERRORS.md) for human-readable explanations.


### PR DESCRIPTION
resolved #20 

@JerryIdoko should I also create the error struct and update the code base or you would make it a standalone issue?

``` rust
#[contracterror]
#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
#[repr(u32)]
pub enum GrantError {
    NotAuthorized = 1,
    InsufficientBalance = 2,
    GrantNotFound = 3,
    GrantPaused = 4,
    InvalidAmount = 5,
    AlreadyExists = 6,
    UnderDisputeBlocked = 7,
}
```