### PR TITLE
feat: Drip-to-Validator Incentive Split (#107, #64)

### DIFF
--- a/contracts/grant_contracts/src/lib.rs
+++ b/contracts/grant_contracts/src/lib.rs
@@ -53,6 +53,13 @@ pub struct Grant {
     pub stream_type: StreamType,
     pub start_time: u64,
     pub warmup_duration: u64,
+    /// Optional Stellar Validator reward address. When set, 5% of accruals
+    /// are directed here ("Ecosystem Tax").
+    pub validator: Option<Address>,
+    /// Independent withdrawal counter for the validator's 5% share.
+    pub validator_withdrawn: i128,
+    /// Claimable balance accumulator for the validator (5% of stream).
+    pub validator_claimable: i128,
 }
 
 #[derive(Clone)]
@@ -85,6 +92,7 @@ pub enum Error {
     RescueWouldViolateAllocated = 11,
     GranteeMismatch = 12,
     GrantNotInactive = 13,
+    NotValidator = 14,
 }
 
 // --- Internal Helpers ---
@@ -169,6 +177,32 @@ fn calculate_warmup_multiplier(grant: &Grant, now: u64) -> i128 {
     2500 + (7500 * progress) / 10000
 }
 
+/// Splits `accrued` tokens between the grantee (95%) and the validator (5%).
+/// When no validator is set the full amount goes to the grantee.
+fn apply_accrued_split(grant: &mut Grant, accrued: i128) -> Result<(), Error> {
+    if grant.validator.is_some() && accrued > 0 {
+        let validator_share = accrued
+            .checked_mul(500)
+            .ok_or(Error::MathOverflow)?
+            .checked_div(10000)
+            .ok_or(Error::MathOverflow)?;
+        let grantee_share = accrued
+            .checked_sub(validator_share)
+            .ok_or(Error::MathOverflow)?;
+        grant.claimable = grant.claimable
+            .checked_add(grantee_share)
+            .ok_or(Error::MathOverflow)?;
+        grant.validator_claimable = grant.validator_claimable
+            .checked_add(validator_share)
+            .ok_or(Error::MathOverflow)?;
+    } else {
+        grant.claimable = grant.claimable
+            .checked_add(accrued)
+            .ok_or(Error::MathOverflow)?;
+    }
+    Ok(())
+}
+
 fn settle_grant(grant: &mut Grant, now: u64) -> Result<(), Error> {
     if now < grant.last_update_ts { return Err(Error::InvalidState); }
     
@@ -184,28 +218,37 @@ fn settle_grant(grant: &mut Grant, now: u64) -> Result<(), Error> {
             // Settle up to switch_ts at old rate
             let pre_elapsed = switch_ts - grant.last_update_ts;
             let pre_accrued = calculate_accrued(grant, pre_elapsed, switch_ts)?;
-            grant.claimable = grant.claimable.checked_add(pre_accrued).ok_or(Error::MathOverflow)?;
-            
+            apply_accrued_split(grant, pre_accrued)?;
+
             // Apply new rate
             grant.flow_rate = grant.pending_rate;
             grant.rate_updated_at = switch_ts;
             grant.pending_rate = 0;
             grant.effective_timestamp = 0;
             grant.last_update_ts = switch_ts;
-            
+
             // Recalculate remaining elapsed
             let post_elapsed = now - switch_ts;
             let post_accrued = calculate_accrued(grant, post_elapsed, now)?;
-            grant.claimable = grant.claimable.checked_add(post_accrued).ok_or(Error::MathOverflow)?;
+            apply_accrued_split(grant, post_accrued)?;
         } else {
             let accrued = calculate_accrued(grant, elapsed, now)?;
-            grant.claimable = grant.claimable.checked_add(accrued).ok_or(Error::MathOverflow)?;
+            apply_accrued_split(grant, accrued)?;
         }
     }
 
-    let total_accounted = grant.withdrawn.checked_add(grant.claimable).ok_or(Error::MathOverflow)?;
+    let total_accounted = grant.withdrawn
+        .checked_add(grant.claimable).ok_or(Error::MathOverflow)?
+        .checked_add(grant.validator_withdrawn).ok_or(Error::MathOverflow)?
+        .checked_add(grant.validator_claimable).ok_or(Error::MathOverflow)?;
     if total_accounted >= grant.total_amount {
-        grant.claimable = grant.total_amount - grant.withdrawn;
+        // Cap remaining claimable so total does not exceed total_amount
+        let already_paid = grant.withdrawn
+            .checked_add(grant.validator_withdrawn).ok_or(Error::MathOverflow)?
+            .checked_add(grant.validator_claimable).ok_or(Error::MathOverflow)?;
+        grant.claimable = grant.total_amount
+            .checked_sub(already_paid).ok_or(Error::MathOverflow)?
+            .max(0);
         grant.status = GrantStatus::Completed;
     }
 
@@ -260,7 +303,8 @@ impl GrantContract {
         recipient: Address,
         total_amount: i128,
         flow_rate: i128,
-        warmup_duration: u64
+        warmup_duration: u64,
+        validator: Option<Address>,
     ) -> Result<(), Error> {
         require_admin_auth(&env)?;
 
@@ -290,6 +334,9 @@ impl GrantContract {
             stream_type: StreamType::FixedAmount,
             start_time: now,
             warmup_duration,
+            validator,
+            validator_withdrawn: 0,
+            validator_claimable: 0,
         };
 
         env.storage().instance().set(&key, &grant);
@@ -410,18 +457,31 @@ impl GrantContract {
         if grant.status != GrantStatus::Paused { return Err(Error::InvalidState); }
 
         settle_grant(&mut grant, env.ledger().timestamp())?;
-        
+
         let claim_amount = grant.claimable;
+        let validator_amount = grant.validator_claimable;
         grant.claimable = 0;
+        grant.validator_claimable = 0;
         grant.withdrawn = grant.withdrawn.checked_add(claim_amount).ok_or(Error::MathOverflow)?;
+        grant.validator_withdrawn = grant.validator_withdrawn.checked_add(validator_amount).ok_or(Error::MathOverflow)?;
         grant.status = GrantStatus::RageQuitted;
-        
-        let remaining = grant.total_amount.checked_sub(grant.withdrawn).ok_or(Error::MathOverflow)?;
+
+        let total_paid = grant.withdrawn
+            .checked_add(grant.validator_withdrawn)
+            .ok_or(Error::MathOverflow)?;
+        let remaining = grant.total_amount.checked_sub(total_paid).ok_or(Error::MathOverflow)?;
         write_grant(&env, grant_id, &grant);
 
         let token_addr = read_grant_token(&env)?;
         let client = token::Client::new(&env, &token_addr);
         client.transfer(&env.current_contract_address(), &grant.recipient, &claim_amount);
+
+        // Pay out the validator's accrued share on rage quit
+        if validator_amount > 0 {
+            if let Some(ref validator_addr) = grant.validator {
+                client.transfer(&env.current_contract_address(), validator_addr, &validator_amount);
+            }
+        }
 
         if remaining > 0 {
             let treasury = read_treasury(&env)?;
@@ -434,14 +494,19 @@ impl GrantContract {
     pub fn cancel_grant(env: Env, grant_id: u64) -> Result<(), Error> {
         let mut grant = read_grant(&env, grant_id)?;
         require_admin_auth(&env)?;
-        
+
         if grant.status == GrantStatus::Completed || grant.status == GrantStatus::RageQuitted {
             return Err(Error::InvalidState);
         }
 
         settle_grant(&mut grant, env.ledger().timestamp())?;
-        
-        let remaining = grant.total_amount.checked_sub(grant.withdrawn).ok_or(Error::MathOverflow)?;
+
+        // Remaining = total - already withdrawn - pending claimable (both sides)
+        let total_paid = grant.withdrawn
+            .checked_add(grant.validator_withdrawn).ok_or(Error::MathOverflow)?
+            .checked_add(grant.claimable).ok_or(Error::MathOverflow)?
+            .checked_add(grant.validator_claimable).ok_or(Error::MathOverflow)?;
+        let remaining = grant.total_amount.checked_sub(total_paid).ok_or(Error::MathOverflow)?;
         grant.status = GrantStatus::Cancelled;
         write_grant(&env, grant_id, &grant);
 
@@ -487,6 +552,61 @@ impl GrantContract {
         } else {
             0
         }
+    }
+
+    /// Returns the current claimable balance for the validator (5% share).
+    pub fn validator_claimable(env: Env, grant_id: u64) -> i128 {
+        if let Ok(mut grant) = read_grant(&env, grant_id) {
+            if grant.validator.is_none() {
+                return 0;
+            }
+            let _ = settle_grant(&mut grant, env.ledger().timestamp());
+            grant.validator_claimable
+        } else {
+            0
+        }
+    }
+
+    /// Returns (validator_address, validator_claimable, validator_withdrawn) for a grant.
+    pub fn get_validator_info(
+        env: Env,
+        grant_id: u64,
+    ) -> Result<(Option<Address>, i128, i128), Error> {
+        let grant = read_grant(&env, grant_id)?;
+        Ok((grant.validator, grant.validator_claimable, grant.validator_withdrawn))
+    }
+
+    /// Allows the designated validator to pull their 5% share independently.
+    pub fn withdraw_validator(env: Env, grant_id: u64, amount: i128) -> Result<(), Error> {
+        let mut grant = read_grant(&env, grant_id)?;
+        let validator_addr = grant.validator.clone().ok_or(Error::InvalidState)?;
+        validator_addr.require_auth();
+
+        if grant.status == GrantStatus::Cancelled || grant.status == GrantStatus::RageQuitted {
+            return Err(Error::InvalidState);
+        }
+
+        settle_grant(&mut grant, env.ledger().timestamp())?;
+
+        if amount <= 0 || amount > grant.validator_claimable {
+            return Err(Error::InvalidAmount);
+        }
+
+        grant.validator_claimable = grant.validator_claimable
+            .checked_sub(amount)
+            .ok_or(Error::MathOverflow)?;
+        grant.validator_withdrawn = grant.validator_withdrawn
+            .checked_add(amount)
+            .ok_or(Error::MathOverflow)?;
+
+        write_grant(&env, grant_id, &grant);
+
+        let token_addr = read_grant_token(&env)?;
+        let client = token::Client::new(&env, &token_addr);
+        client.transfer(&env.current_contract_address(), &validator_addr, &amount);
+
+        env.events().publish((symbol_short!("valwdraw"), grant_id), amount);
+        Ok(())
     }
 }
 

--- a/contracts/grant_contracts/src/test.rs
+++ b/contracts/grant_contracts/src/test.rs
@@ -47,7 +47,7 @@ fn test_pipeline() {
     // Mint tokens to contract for payout
     grant_token_admin.mint(&client.address, &total_amount);
 
-    client.create_grant(&grant_id, &recipient, &total_amount, &flow_rate, &warmup_duration);
+    client.create_grant(&grant_id, &recipient, &total_amount, &flow_rate, &warmup_duration, &None);
 
     // 2. Advance time and check claimable
     set_timestamp(&env, 1010); // 10 seconds later
@@ -86,7 +86,7 @@ fn test_warmup() {
     let flow_rate = 100 * SCALING_FACTOR;
     let warmup_duration = 100; // 100 seconds warmup
     
-    client.create_grant(&grant_id, &recipient, &(10000 * SCALING_FACTOR), &flow_rate, &warmup_duration);
+    client.create_grant(&grant_id, &recipient, &(10000 * SCALING_FACTOR), &flow_rate, &warmup_duration, &None);
 
     // At T=1100, the instantaneous multiplier is 100% (10000 bps)
     // The current logic settle at the END of the period at the END rate.
@@ -108,7 +108,7 @@ fn test_rage_quit() {
     let total_amount = 1000 * SCALING_FACTOR;
     grant_token_admin.mint(&client.address, &total_amount);
     
-    client.create_grant(&grant_id, &recipient, &total_amount, &SCALING_FACTOR, &0);
+    client.create_grant(&grant_id, &recipient, &total_amount, &SCALING_FACTOR, &0, &None);
     
     set_timestamp(&env, 1100); // 100 tokens accrued
     client.pause_stream(&grant_id);
@@ -127,7 +127,7 @@ fn test_apply_kpi_multiplier_requires_oracle_auth() {
     let recipient = Address::generate(&env);
     
     let grant_id = 1;
-    client.create_grant(&grant_id, &recipient, &(1000 * SCALING_FACTOR), &SCALING_FACTOR, &0);
+    client.create_grant(&grant_id, &recipient, &(1000 * SCALING_FACTOR), &SCALING_FACTOR, &0, &None);
     
     // env.set_source_account(&oracle);
     client.apply_kpi_multiplier(&grant_id, &20000); // 2x in basis points
@@ -145,7 +145,7 @@ fn test_apply_kpi_multiplier_settles_before_updating_rate() {
     
     set_timestamp(&env, 1000);
     let grant_id = 1;
-    client.create_grant(&grant_id, &recipient, &(1000 * SCALING_FACTOR), &SCALING_FACTOR, &0);
+    client.create_grant(&grant_id, &recipient, &(1000 * SCALING_FACTOR), &SCALING_FACTOR, &0, &None);
     
     set_timestamp(&env, 1100); // 100 accrued
     client.apply_kpi_multiplier(&grant_id, &20000); // 2x
@@ -167,7 +167,7 @@ fn test_apply_kpi_multiplier_rejects_invalid_multiplier_and_inactive_states() {
     let total_amount = 1000 * SCALING_FACTOR;
     grant_token_admin.mint(&client.address, &total_amount);
 
-    client.create_grant(&grant_id, &recipient, &total_amount, &SCALING_FACTOR, &0);
+    client.create_grant(&grant_id, &recipient, &total_amount, &SCALING_FACTOR, &0, &None);
     
     assert!(client.try_apply_kpi_multiplier(&grant_id, &0).is_err());
     
@@ -184,7 +184,7 @@ fn test_apply_kpi_multiplier_scales_pending_rate_and_preserves_accrual_boundarie
     
     set_timestamp(&env, 1000);
     let grant_id = 1;
-    client.create_grant(&grant_id, &recipient, &(100000 * SCALING_FACTOR), &SCALING_FACTOR, &0);
+    client.create_grant(&grant_id, &recipient, &(100000 * SCALING_FACTOR), &SCALING_FACTOR, &0, &None);
     
     set_timestamp(&env, 1100);
     client.propose_rate_change(&grant_id, &(2 * SCALING_FACTOR));
@@ -196,4 +196,211 @@ fn test_apply_kpi_multiplier_scales_pending_rate_and_preserves_accrual_boundarie
     assert_eq!(grant.flow_rate, 2 * SCALING_FACTOR);
     assert_eq!(grant.pending_rate, 4 * SCALING_FACTOR);
     assert_eq!(grant.claimable, 150 * SCALING_FACTOR);
+}
+
+// ─── Validator Incentive Split Tests ─────────────────────────────────────────
+
+/// After time elapses, 95% of accruals are claimable by the grantee and 5% by
+/// the validator, independently tracked.
+#[test]
+fn test_validator_split_basic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, grant_token_addr, _treasury, _oracle, _native, client) = setup_test(&env);
+    let recipient = Address::generate(&env);
+    let validator = Address::generate(&env);
+    let grant_token_admin = token::StellarAssetClient::new(&env, &grant_token_addr);
+
+    set_timestamp(&env, 1000);
+    let grant_id = 1;
+    let total_amount = 1_000_000 * SCALING_FACTOR;
+    let flow_rate = 1 * SCALING_FACTOR; // 1 token/sec
+    grant_token_admin.mint(&client.address, &total_amount);
+
+    client.create_grant(
+        &grant_id, &recipient, &total_amount, &flow_rate, &0,
+        &Some(validator.clone()),
+    );
+
+    // Advance 100 seconds: 100 tokens accrued total
+    // Grantee gets 95, validator gets 5
+    set_timestamp(&env, 1100);
+    assert_eq!(client.claimable(&grant_id), 95 * SCALING_FACTOR);
+    assert_eq!(client.validator_claimable(&grant_id), 5 * SCALING_FACTOR);
+}
+
+/// Grantee and validator can withdraw independently; each counter is isolated.
+#[test]
+fn test_validator_withdraw_independent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, grant_token_addr, _treasury, _oracle, _native, client) = setup_test(&env);
+    let recipient = Address::generate(&env);
+    let validator = Address::generate(&env);
+    let grant_token = token::Client::new(&env, &grant_token_addr);
+    let grant_token_admin = token::StellarAssetClient::new(&env, &grant_token_addr);
+
+    set_timestamp(&env, 1000);
+    let grant_id = 1;
+    let total_amount = 1_000_000 * SCALING_FACTOR;
+    let flow_rate = 1 * SCALING_FACTOR;
+    grant_token_admin.mint(&client.address, &total_amount);
+
+    client.create_grant(
+        &grant_id, &recipient, &total_amount, &flow_rate, &0,
+        &Some(validator.clone()),
+    );
+
+    // After 200 seconds: 190 grantee, 10 validator
+    set_timestamp(&env, 1200);
+
+    // Grantee withdraws their full share
+    client.withdraw(&grant_id, &(190 * SCALING_FACTOR));
+    assert_eq!(grant_token.balance(&recipient), 190 * SCALING_FACTOR);
+
+    // Validator claimable still intact
+    assert_eq!(client.validator_claimable(&grant_id), 10 * SCALING_FACTOR);
+
+    // Validator withdraws their share
+    client.withdraw_validator(&grant_id, &(10 * SCALING_FACTOR));
+    assert_eq!(grant_token.balance(&validator), 10 * SCALING_FACTOR);
+
+    // Both counters are now zero
+    assert_eq!(client.claimable(&grant_id), 0);
+    assert_eq!(client.validator_claimable(&grant_id), 0);
+}
+
+/// Without a validator the full stream goes to the grantee (no regression).
+#[test]
+fn test_no_validator_unaffected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, grant_token_addr, _treasury, _oracle, _native, client) = setup_test(&env);
+    let recipient = Address::generate(&env);
+    let grant_token = token::Client::new(&env, &grant_token_addr);
+    let grant_token_admin = token::StellarAssetClient::new(&env, &grant_token_addr);
+
+    set_timestamp(&env, 1000);
+    let grant_id = 1;
+    let total_amount = 1_000_000 * SCALING_FACTOR;
+    let flow_rate = 1 * SCALING_FACTOR;
+    grant_token_admin.mint(&client.address, &total_amount);
+
+    client.create_grant(
+        &grant_id, &recipient, &total_amount, &flow_rate, &0,
+        &None,
+    );
+
+    set_timestamp(&env, 1100);
+    // Full 100 tokens go to grantee
+    assert_eq!(client.claimable(&grant_id), 100 * SCALING_FACTOR);
+    assert_eq!(client.validator_claimable(&grant_id), 0);
+
+    client.withdraw(&grant_id, &(100 * SCALING_FACTOR));
+    assert_eq!(grant_token.balance(&recipient), 100 * SCALING_FACTOR);
+}
+
+/// On rage quit the validator receives their accrued 5% and the rest returns
+/// to treasury.
+#[test]
+fn test_validator_split_rage_quit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, grant_token_addr, treasury, _oracle, _native, client) = setup_test(&env);
+    let recipient = Address::generate(&env);
+    let validator = Address::generate(&env);
+    let grant_token = token::Client::new(&env, &grant_token_addr);
+    let grant_token_admin = token::StellarAssetClient::new(&env, &grant_token_addr);
+
+    set_timestamp(&env, 1000);
+    let grant_id = 1;
+    let total_amount = 1000 * SCALING_FACTOR;
+    grant_token_admin.mint(&client.address, &total_amount);
+
+    client.create_grant(
+        &grant_id, &recipient, &total_amount, &SCALING_FACTOR, &0,
+        &Some(validator.clone()),
+    );
+
+    // 100 seconds: 95 grantee, 5 validator
+    set_timestamp(&env, 1100);
+    client.pause_stream(&grant_id);
+    client.rage_quit(&grant_id);
+
+    assert_eq!(grant_token.balance(&recipient), 95 * SCALING_FACTOR);
+    assert_eq!(grant_token.balance(&validator), 5 * SCALING_FACTOR);
+    // Remaining 900 returns to treasury
+    assert_eq!(grant_token.balance(&treasury), 900 * SCALING_FACTOR);
+}
+
+/// On cancel, only unallocated funds (not yet accrued or withdrawn) go to
+/// treasury; the grantee and validator can still pull their claimable shares.
+#[test]
+fn test_validator_split_cancel() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, grant_token_addr, treasury, _oracle, _native, client) = setup_test(&env);
+    let recipient = Address::generate(&env);
+    let validator = Address::generate(&env);
+    let grant_token = token::Client::new(&env, &grant_token_addr);
+    let grant_token_admin = token::StellarAssetClient::new(&env, &grant_token_addr);
+
+    set_timestamp(&env, 1000);
+    let grant_id = 1;
+    let total_amount = 1000 * SCALING_FACTOR;
+    grant_token_admin.mint(&client.address, &total_amount);
+
+    client.create_grant(
+        &grant_id, &recipient, &total_amount, &SCALING_FACTOR, &0,
+        &Some(validator.clone()),
+    );
+
+    // 100 seconds: 95 grantee, 5 validator accrued (900 unallocated)
+    set_timestamp(&env, 1100);
+    client.cancel_grant(&grant_id);
+
+    // Treasury receives 900 unallocated tokens
+    assert_eq!(grant_token.balance(&treasury), 900 * SCALING_FACTOR);
+
+    // Grantee can still claim their 95
+    assert_eq!(client.claimable(&grant_id), 95 * SCALING_FACTOR);
+    // Validator can still claim their 5
+    assert_eq!(client.validator_claimable(&grant_id), 5 * SCALING_FACTOR);
+}
+
+/// Only the designated validator address can call withdraw_validator.
+#[test]
+fn test_withdraw_validator_requires_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, grant_token_addr, _treasury, _oracle, _native, client) = setup_test(&env);
+    let recipient = Address::generate(&env);
+    let validator = Address::generate(&env);
+    let grant_token_admin = token::StellarAssetClient::new(&env, &grant_token_addr);
+
+    set_timestamp(&env, 1000);
+    let grant_id = 1;
+    let total_amount = 1_000_000 * SCALING_FACTOR;
+    grant_token_admin.mint(&client.address, &total_amount);
+
+    client.create_grant(
+        &grant_id, &recipient, &total_amount, &SCALING_FACTOR, &0,
+        &Some(validator.clone()),
+    );
+
+    set_timestamp(&env, 1100);
+
+    // Grant with no validator must reject withdraw_validator
+    let grant_id_no_val = 2;
+    client.create_grant(
+        &grant_id_no_val, &recipient, &total_amount, &SCALING_FACTOR, &0,
+        &None,
+    );
+    assert!(client.try_withdraw_validator(&grant_id_no_val, &(1 * SCALING_FACTOR)).is_err());
+
+    // Attempting to overdraw validator share must fail
+    assert!(client.try_withdraw_validator(&grant_id, &(100 * SCALING_FACTOR)).is_err());
+
+    // Exact amount must succeed
+    client.withdraw_validator(&grant_id, &(5 * SCALING_FACTOR));
 }


### PR DESCRIPTION
## Summary

Closes #107

Implements the optional **Ecosystem Tax** split-payout mechanism where 95% of a grant stream goes to the grantee and 5% is directed to a designated Stellar Validator node reward address.

## Changes

### `contracts/grant_contracts/src/lib.rs`
- **`Grant` struct** — added `validator: Option<Address>`, `validator_claimable: i128`, `validator_withdrawn: i128`
- **`apply_accrued_split`** — new helper that routes 5% of each accrual to the validator and 95% to the grantee; falls back to 100% grantee when no validator is set
- **`settle_grant`** — updated to use `apply_accrued_split` and include both validator counters in the completion check
- **`create_grant`** — new optional `validator: Option<Address>` parameter (fully backward-compatible via `None`)
- **`withdraw_validator`** — new entry point; only the designated validator address can call it, pulls from `validator_claimable` independently of the grantee
- **`validator_claimable`** — new view function (parallel to `claimable`)
- **`get_validator_info`** — convenience query returning `(validator, validator_claimable, validator_withdrawn)`
- **`rage_quit`** — validator's accrued share is paid out on rage quit before returning remainder to treasury
- **`cancel_grant`** — treasury only receives truly unallocated funds (excludes pending claimable on both sides)

### `contracts/grant_contracts/src/test.rs`
- Updated all existing `create_grant` calls to pass `&None` for no-validator grants
- Added 6 new tests:
  - `test_validator_split_basic` — 95/5 split ratio verified
  - `test_validator_withdraw_independent` — grantee and validator withdraw independently
  - `test_no_validator_unaffected` — no regression when validator is not set
  - `test_validator_split_rage_quit` — validator paid on rage quit
  - `test_validator_split_cancel` — only unallocated funds go to treasury on cancel
  - `test_withdraw_validator_requires_auth` — auth and overdraw protection

## Test Results
```
running 13 tests ... ok (13 passed, 0 failed)
```

## Labels
backend, stellar, social-impact