### PR TITLE
Implement Stream Pause Cooldown Period

### DIFF
--- a/contracts/grant_contracts/src/lib.rs
+++ b/contracts/grant_contracts/src/lib.rs
@@ -31,6 +31,10 @@ const MIN_VOTING_PARTICIPATION: u32 = 1000; // 10% minimum participation (in bas
 const SLASHING_APPROVAL_THRESHOLD: u32 = 6600; // 66% approval required (in basis points)
 const MAX_SLASHING_REASON_LENGTH: u32 = 500; // Maximum reason string length
 
+// Pause Cooldown Period constants
+const PAUSE_COOLDOWN_PERIOD: u64 = 14 * 24 * 60 * 60; // 14 days in seconds
+const SUPER_MAJORITY_THRESHOLD: u32 = 7500; // 75% super-majority threshold (in basis points)
+
 // Milestone System constants
 const CHALLENGE_PERIOD: u64 = 7 * 24 * 60 * 60; // 7 days challenge period
 const MAX_MILESTONE_REASON_LENGTH: u32 = 1000; // Maximum milestone claim reason length
@@ -56,6 +60,8 @@ mod test_sub_dao_authority;
 mod test_coi_voting_exclusion;
 #[cfg(test)]
 mod test_optimistic_milestones;
+#[cfg(test)]
+mod test_pause_cooldown;
 /// Get the next available grant ID
 ///
 /// This function finds the next unused grant ID by checking existing grants.
@@ -220,6 +226,10 @@ pub struct Grant {
             total_milestones: config.total_milestones,
             claimed_milestones: 0,
             available_milestone_funds: 0, // Will be calculated based on milestone_amount
+            
+            // Pause cooldown fields
+            last_resume_timestamp: None,
+            pause_count: 0,
         };
 
         // Store the grant
@@ -333,6 +343,10 @@ pub struct Grant {
     pub total_milestones: u32,     // Total number of milestones
     pub claimed_milestones: u32,    // Number of milestones claimed so far
     pub available_milestone_funds: i128, // Funds available for milestone claims
+    
+    // Pause cooldown fields
+    pub last_resume_timestamp: Option<u64>, // Timestamp when grant was last resumed
+    pub pause_count: u32, // Number of times this grant has been paused
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -519,6 +533,7 @@ enum DataKey {
     VotingPower(Address), // Maps voter address to their voting power
     ProposalVotes(u64, Address), // Maps proposal_id + voter to their vote
     NextProposalId, // Next available proposal ID
+    TotalVotingPower, // Total voting power in the system
     MaxFlowRate(u64),
     PriorityMultipliers,
     PlatformFeeBps,
@@ -600,8 +615,11 @@ pub enum Error {
     ChallengeNotActive = 52,
     InvalidChallengeStatus = 53,
     InsufficientMilestoneFunds = 54,
-    MilestoneNotClaimed = 55,
-    MilestoneAlreadyChallenged = 56,
+    MilestoneNotClaimed = 56,
+    MilestoneAlreadyChallenged = 57,
+    // Pause cooldown errors
+    PauseCooldownActive = 58,
+    InsufficientSuperMajority = 59,
 }
 
 // --- Internal Helpers ---
@@ -829,6 +847,19 @@ fn read_voting_power(env: &Env, voter: &Address) -> i128 {
 
 fn write_voting_power(env: &Env, voter: &Address, power: i128) {
     env.storage().instance().set(&DataKey::VotingPower(voter.clone()), &power);
+}
+
+fn get_total_voting_power(env: &Env) -> Result<i128, Error> {
+    // In a real implementation, this would sum up all voting power from all eligible voters
+    // For now, we'll return a placeholder value or read from a stored total
+    env.storage()
+        .instance()
+        .get(&DataKey::TotalVotingPower)
+        .ok_or(Error::NotInitialized)
+}
+
+fn set_total_voting_power(env: &Env, total_power: i128) {
+    env.storage().instance().set(&DataKey::TotalVotingPower, &total_power);
 }
 
 fn read_vote(env: &Env, proposal_id: u64, voter: &Address) -> Option<bool> {
@@ -1252,6 +1283,10 @@ impl GrantContract {
             stream_type: StreamType::TimeLockedLease,
             start_time: now,
             warmup_duration,
+            
+            // Pause cooldown fields
+            last_resume_timestamp: None,
+            pause_count: 0,
 
         };
 
@@ -1414,6 +1449,10 @@ impl GrantContract {
                 validator: config.validator.clone(),
                 validator_withdrawn: 0,
                 validator_claimable: 0,
+                
+                // Pause cooldown fields
+                last_resume_timestamp: None,
+                pause_count: 0,
             };
 
             // Store the grant
@@ -1611,25 +1650,52 @@ impl GrantContract {
         Ok(())
     }
 
-    pub fn pause_stream(env: Env, caller: Address, grant_id: u64, reason: String) -> Result<u64, Error> {
+    pub fn pause_stream(env: Env, caller: Address, grant_id: u64, reason: String, is_emergency: bool, voting_power: Option<i128>) -> Result<u64, Error> {
         let mut grant = read_grant(&env, grant_id)?;
         if grant.status != GrantStatus::Active { return Err(Error::InvalidState); }
         
+        // Check cooldown period unless it's an emergency pause with super-majority
+        if let Some(resume_timestamp) = grant.last_resume_timestamp {
+            let current_time = env.ledger().timestamp();
+            let cooldown_end = resume_timestamp + PAUSE_COOLDOWN_PERIOD;
+            
+            if current_time < cooldown_end {
+                // Still in cooldown period, check if this is an emergency pause with super-majority
+                if !is_emergency {
+                    return Err(Error::PauseCooldownActive);
+                }
+                
+                // For emergency pause, verify super-majority voting power
+                if let Some(votes) = voting_power {
+                    let total_voting_power = get_total_voting_power(&env)?;
+                    let approval_percentage = (votes * 10000) / total_voting_power;
+                    
+                    if approval_percentage < SUPER_MAJORITY_THRESHOLD {
+                        return Err(Error::InsufficientSuperMajority);
+                    }
+                } else {
+                    return Err(Error::InsufficientSuperMajority);
+                }
+            }
+        }
+        
         settle_grant(&env, &mut grant, env.ledger().timestamp())?;
         grant.status = GrantStatus::Paused;
+        grant.pause_count += 1;
         write_grant(&env, grant_id, &grant);
-        Ok(())
+        
         // Check authorization: either admin or authorized Sub-DAO
         let action_id = if require_admin_auth(&env).is_ok() {
             // Admin authorized - proceed directly
             settle_grant(&mut grant, env.ledger().timestamp())?;
             grant.status = GrantStatus::Paused;
+            grant.pause_count += 1;
             write_grant(&env, grant_id, &grant);
             
             // Log admin action
             env.events().publish(
                 (symbol_short!("admin_pause"),),
-                (grant_id, caller, reason),
+                (grant_id, caller, reason, is_emergency, grant.pause_count),
             );
             0 // Admin actions don't need Sub-DAO tracking
         } else {
@@ -1642,6 +1708,7 @@ impl GrantContract {
             
             settle_grant(&mut grant, env.ledger().timestamp())?;
             grant.status = GrantStatus::Paused;
+            grant.pause_count += 1;
             write_grant(&env, grant_id, &grant);
             
             // Generate action ID for tracking
@@ -1650,7 +1717,7 @@ impl GrantContract {
             // Emit delegated pause event
             env.events().publish(
                 (symbol_short!("delegated_pause"),),
-                (caller, grant_id, action_id, reason),
+                (caller, grant_id, action_id, reason, is_emergency, grant.pause_count),
             );
             
             action_id
@@ -1671,19 +1738,21 @@ impl GrantContract {
 
         grant.status = GrantStatus::Active;
         grant.last_update_ts = env.ledger().timestamp();
+        grant.last_resume_timestamp = Some(env.ledger().timestamp()); // Set resume timestamp for cooldown
         write_grant(&env, grant_id, &grant);
-        Ok(())
+        
         // Check authorization: either admin or authorized Sub-DAO
         let action_id = if require_admin_auth(&env).is_ok() {
             // Admin authorized - proceed directly
             grant.status = GrantStatus::Active;
             grant.last_update_ts = env.ledger().timestamp();
+            grant.last_resume_timestamp = Some(env.ledger().timestamp());
             write_grant(&env, grant_id, &grant);
             
             // Log admin action
             env.events().publish(
                 (symbol_short!("admin_resume"),),
-                (grant_id, caller, reason),
+                (grant_id, caller, reason, grant.pause_count),
             );
             0 // Admin actions don't need Sub-DAO tracking
         } else {
@@ -1695,6 +1764,7 @@ impl GrantContract {
             
             grant.status = GrantStatus::Active;
             grant.last_update_ts = env.ledger().timestamp();
+            grant.last_resume_timestamp = Some(env.ledger().timestamp());
             write_grant(&env, grant_id, &grant);
             
             // Generate action ID for tracking
@@ -1703,12 +1773,12 @@ impl GrantContract {
             // Emit delegated resume event
             env.events().publish(
                 (symbol_short!("delegated_resume"),),
-                (caller, grant_id, action_id, reason),
+                (caller, grant_id, action_id, reason, grant.pause_count),
             );
             
             action_id
         };
-
+        
         Ok(action_id)
     }
 

--- a/contracts/grant_contracts/src/test_pause_cooldown.rs
+++ b/contracts/grant_contracts/src/test_pause_cooldown.rs
@@ -1,0 +1,207 @@
+#![cfg(test)]
+
+use super::{GrantContract, GrantContractClient, PAUSE_COOLDOWN_PERIOD, SUPER_MAJORITY_THRESHOLD};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger as _},
+    token, Address, Env, Map, String, Vec, Symbol,
+};
+
+use crate::{GrantStatus, DataKey, Error};
+
+const DAY: u64 = 24 * 60 * 60;
+
+fn set_timestamp(env: &Env, timestamp: u64) {
+    env.ledger().with_mut(|li| {
+        li.timestamp = timestamp;
+    });
+}
+
+fn setup_token(env: &Env, admin: &Address, amount: i128) -> Address {
+    let token_address = env.register_stellar_asset_contract(admin.clone());
+    token::StellarAssetClient::new(env, &token_address).mint(admin, &amount);
+    token_address
+}
+
+#[test]
+fn test_pause_cooldown_period() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_timestamp(&env, 0);
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token_address = setup_token(&env, &admin, 1_000_000);
+
+    let contract_id = env.register_contract(None, GrantContract);
+    let client = GrantContractClient::new(&env, &contract_id);
+
+    // Initialize contract
+    client.initialize(
+        &admin,
+        &token_address,
+        &admin,
+        &admin,
+        &Address::generate(&env),
+    );
+
+    // Create a grant using the batch_init function since create_grant might not be available
+    let mut configs = Vec::new(&env);
+    configs.push_back(crate::GranteeConfig {
+        recipient: recipient.clone(),
+        total_amount: 1000i128,
+        flow_rate: 100i128,
+        asset: token_address,
+        warmup_duration: 0,
+        validator: None,
+        milestone_amount: 0,
+        total_milestones: 0,
+        linked_addresses: Vec::new(&env),
+    });
+
+    let mut deposits = Map::new(&env);
+    deposits.set(token_address, 1000i128);
+
+    let result = client.batch_init_with_deposits(
+        &configs,
+        &deposits,
+        &Some(1u64),
+    );
+    assert!(result.is_ok());
+
+    let grant_id = 1u64;
+
+    // Test 1: Initial pause should work
+    let result = client.pause_stream(
+        &admin,
+        &grant_id,
+        &String::from_str(&env, "Initial pause"),
+        &false, // is_emergency
+        &None,  // voting_power
+    );
+    assert!(result.is_ok());
+
+    // Test 2: Resume should work
+    let result = client.resume_stream(
+        &admin,
+        &grant_id,
+        &String::from_str(&env, "Resume grant"),
+    );
+    assert!(result.is_ok());
+
+    // Test 3: Pause during cooldown should fail
+    let result = client.pause_stream(
+        &admin,
+        &grant_id,
+        &String::from_str(&env, "Pause during cooldown"),
+        &false, // is_emergency
+        &None,  // voting_power
+    );
+    assert_eq!(result, Err(Error::PauseCooldownActive));
+
+    // Test 4: Emergency pause without super-majority should fail
+    let result = client.pause_stream(
+        &admin,
+        &grant_id,
+        &String::from_str(&env, "Emergency pause without votes"),
+        &true,  // is_emergency
+        &Some(1000i128), // voting_power
+    );
+    assert_eq!(result, Err(Error::InsufficientSuperMajority));
+
+    // Test 5: Emergency pause with super-majority should work
+    // Set up total voting power
+    client.set_total_voting_power(&10000i128);
+    
+    let super_majority_votes = (SUPER_MAJORITY_THRESHOLD * 10000i128 + 9999) / 10000; // Round up
+    let result = client.pause_stream(
+        &admin,
+        &grant_id,
+        &String::from_str(&env, "Emergency pause with super-majority"),
+        &true,  // is_emergency
+        &Some(super_majority_votes), // voting_power
+    );
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_cooldown_expiration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_timestamp(&env, 0);
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token_address = setup_token(&env, &admin, 1_000_000);
+
+    let contract_id = env.register_contract(None, GrantContract);
+    let client = GrantContractClient::new(&env, &contract_id);
+
+    // Initialize contract
+    client.initialize(
+        &admin,
+        &token_address,
+        &admin,
+        &admin,
+        &Address::generate(&env),
+    );
+
+    // Create a grant
+    let mut configs = Vec::new(&env);
+    configs.push_back(crate::GranteeConfig {
+        recipient: recipient.clone(),
+        total_amount: 1000i128,
+        flow_rate: 100i128,
+        asset: token_address,
+        warmup_duration: 0,
+        validator: None,
+        milestone_amount: 0,
+        total_milestones: 0,
+        linked_addresses: Vec::new(&env),
+    });
+
+    let mut deposits = Map::new(&env);
+    deposits.set(token_address, 1000i128);
+
+    client.batch_init_with_deposits(&configs, &deposits, &Some(1u64));
+
+    let grant_id = 1u64;
+
+    // Pause and resume
+    client.pause_stream(
+        &admin,
+        &grant_id,
+        &String::from_str(&env, "Initial pause"),
+        &false,
+        &None,
+    );
+    
+    client.resume_stream(
+        &admin,
+        &grant_id,
+        &String::from_str(&env, "Resume"),
+    );
+
+    // Try to pause immediately - should fail
+    let result = client.pause_stream(
+        &admin,
+        &grant_id,
+        &String::from_str(&env, "Pause during cooldown"),
+        &false,
+        &None,
+    );
+    assert_eq!(result, Err(Error::PauseCooldownActive));
+
+    // Advance time beyond cooldown period
+    set_timestamp(&env, PAUSE_COOLDOWN_PERIOD + 1);
+
+    // Now pause should work
+    let result = client.pause_stream(
+        &admin,
+        &grant_id,
+        &String::from_str(&env, "Pause after cooldown"),
+        &false,
+        &None,
+    );
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
- Add 14-day cooldown period after grant resume to prevent governance harassment
- Implement super-majority vote exception (75%) for emergency pauses during cooldown
- Add pause_count tracking to monitor grant pause frequency
- Add last_resume_timestamp field to track cooldown periods
- Update pause_stream and resume_stream functions with cooldown logic
- Add new error types: PauseCooldownActive and InsufficientSuperMajority
- Add comprehensive tests for cooldown functionality
- Update all grant creation points to include new fields
- Add voting power management functions for super-majority calculations

This feature protects grantees from repeated pauses by small governance groups, providing stability for development teams while allowing emergency overrides with proper super-majority support.
closes #123