### PR TITLE
feat: implement grantee spending power reporting api #217

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,22 @@ impl GrantContract {
         let max_ttl = env.storage().max_ttl();
         env.storage().instance().extend_ttl(THRESHOLD, max_ttl);
     }
+/// Calculate the real-world purchasing power of a grant amount based on a given inflation rate.
+    /// inflation_rate_bps is expected as a basis point (e.g., 500 = 5%)
+    pub fn get_grantee_spending_power(env: Env, amount: i128, inflation_rate_bps: i128) -> i128 {
+        if amount <= 0 {
+            return 0;
+        }
 
+        // Basis points scaling factor (10,000 = 100.00%)
+        let bps_divisor = 10_000;
+        
+        // Formula: Amount / (1 + Rate)
+        // Scaled for BPS logic: (Amount * 10,000) / (10,000 + Rate_BPS)
+        let adjusted_power = (amount * bps_divisor) / (bps_divisor + inflation_rate_bps);
+
+        adjusted_power
+    }
     // ─── Bridge: Use SubStream revenue as collateral for Grant ───
     pub fn use_substream_as_collateral(env: Env, grant_id: u64, substream_id: u64) -> bool {
         Self::ensure_sufficient_ttl(&env);


### PR DESCRIPTION
Closes #217

---

 Description

Summary
Implemented the Grantee Spending Power Reporting API as requested in Issue #217. This PR adds a read-only utility function to the GrantContract to help foundations calculate the real-world purchasing power of disbursed funds based on local inflation data.

Changes Made
Added get_grantee_spending_power function: A public, read-only function in src/lib.rs.Basis Points (BPS) Integration: Used a $10,000$ divisor to allow for high-precision inflation rates (e.g., $5.5\% = 550$ BPS) without floating-point numbers.Integer-Safe Math: Implemented the adjustment formula using:$$\text{Adjusted Power} = \frac{\text{Amount} \times 10,000}{10,000 + \text{Inflation\_BPS}}$$Validation: Added a check to return 0 if the amount is zero or negative.

Why this is needed
Foundations often grant fixed amounts in stablecoins, but the local value of those tokens can drop significantly in countries with high inflation. This API allows the Grant-Stream dashboard to show "Real-world Impact" metrics, helping donors decide if they need to increase grant sizes to maintain a grantee's standard of living.

TestingBuild:
 Local build was attempted; final verification is pending GitHub Actions CI due to local environment constraints (Windows Linker).Logic Check: Verified the math against manual calculations for $10\%$ and $5\%$ inflation scenarios.