### PR TITLE
feat: implement streaming-fee collector with governance and exemptions

### DIFF
--- a/contracts/contrib/src/streaming_fee.rs
+++ b/contracts/contrib/src/streaming_fee.rs
@@ -1,0 +1,79 @@
+use soroban_sdk::{Env, Address, panic};
+
+#[derive(Clone)]
+pub struct FeeConfig {
+    pub platform_fee_bps: i128, // basis points, 10000 = 100%
+    pub treasury: Address,
+    pub exemptions: Vec<Address>, // fee exemption list
+}
+
+
+pub fn set_platform_fee(env: &Env, new_fee_bps: i128) {
+    require_governance(env);
+    if new_fee_bps < 0 || new_fee_bps > 10000 {
+        panic!("Invalid fee percentage");
+    }
+    env.storage().set("platform_fee_bps", &new_fee_bps);
+}
+
+pub fn set_treasury(env: &Env, treasury: Address) {
+    require_governance(env);
+    env.storage().set("treasury", &treasury);
+}
+
+pub fn add_fee_exemption(env: &Env, addr: Address) {
+    require_governance(env);
+    let mut exemptions: Vec<Address> = env.storage().get("exemptions").unwrap_or(Vec::new(env));
+    if !exemptions.contains(&addr) {
+        exemptions.push(addr);
+        env.storage().set("exemptions", &exemptions);
+    }
+}
+
+pub fn remove_fee_exemption(env: &Env, addr: Address) {
+    require_governance(env);
+    let mut exemptions: Vec<Address> = env.storage().get("exemptions").unwrap_or(Vec::new(env));
+    exemptions.retain(|a| a != &addr);
+    env.storage().set("exemptions", &exemptions);
+}
+
+pub fn apply_streaming_fee(env: &Env, withdrawer: Address, amount: i128) -> (i128, i128) {
+    // Returns (net_amount, fee_amount)
+    let fee_bps: i128 = env.storage().get("platform_fee_bps").unwrap_or(0);
+    let treasury: Address = env.storage().get("treasury").unwrap_or_else(|| panic!("Treasury not set"));
+    let exemptions: Vec<Address> = env.storage().get("exemptions").unwrap_or(Vec::new(env));
+
+    if exemptions.contains(&withdrawer) || fee_bps == 0 {
+        return (amount, 0);
+    }
+
+    let fee = (amount * fee_bps) / 10000;
+    let net = amount - fee;
+
+    // Route fee to treasury vault
+    credit_treasury(env, &treasury, fee);
+
+    // Emit event
+    env.events().publish(
+        (["streaming_fee", "collected"],),
+        (withdrawer, fee, treasury),
+    );
+
+    (net, fee)
+}
+
+fn credit_treasury(env: &Env, treasury: &Address, fee: i128) {
+    // Simplified: increment treasury balance
+    let mut balance: i128 = env.storage().get(&format!("balance:{}", treasury)).unwrap_or(0);
+    balance += fee;
+    env.storage().set(&format!("balance:{}", treasury), &balance);
+}
+
+
+fn require_governance(env: &Env) {
+    let caller = env.invoker();
+    let governor: Address = env.storage().get("governor").unwrap();
+    if caller != governor {
+        panic!("Only governance can call this function");
+    }
+}


### PR DESCRIPTION
# Overview
This PR implements issue **#279 Build "Streaming-Fee" Collector for Protocol Sustainability**.  
It introduces a protocol-level fee mechanism to ensure long-term maintenance of Grant-Stream.

---

## Changes Introduced
- Added `contracts/contrib/src/streaming_fee.rs` with:
  - `FeeConfig` struct (platform_fee_bps, treasury, exemptions)
  - Governance functions:
    - `set_platform_fee`
    - `set_treasury`
    - `add_fee_exemption`
    - `remove_fee_exemption`
  - `apply_streaming_fee` function:
    - Deducts fee from withdrawals
    - Routes fee to treasury vault
    - Emits `["streaming_fee", "collected"]` event
  - Helper `require_governance` for admin-only calls

---

## Acceptance Criteria ✅
- [x] Configurable platform_fee_bps
- [x] Fee routed to treasury vault
- [x] Governance functions to adjust fee
- [x] Fee exemption list implemented
- [x] Event emitted on fee collection
- [x] All work scoped to `contracts/contrib/src/`

---

## How to Test
1. Set treasury and fee percentage via governance.
2. Call `apply_streaming_fee` with withdrawal amount.
3. Confirm:
   - Net amount returned correctly
   - Fee credited to treasury balance
   - Event emitted
4. Add withdrawer to exemption list → confirm no fee deducted.

---

## Contribution Notes
- All work scoped strictly to `contracts/contrib/src/`.
- No files outside this folder were modified.
- Branch: `feat/streaming-fee-collector`

---

## Next Steps
- Add unit tests for fee deduction, exemption, and governance updates.
- Integrate with stream withdrawal logic.

---

## Checklist Before Merge
- [ ] Code reviewed
- [ ] Tests passed locally
- [ ] Events verified
- [ ] Governance functions validated
Closes #279