### PR TITLE
Implement Emergency Manual Revert for Oracle Freeze

### DIFF
--- a/contracts/grant_stream/src/circuit_breakers.rs
+++ b/contracts/grant_stream/src/circuit_breakers.rs
@@ -22,6 +22,8 @@ const PRICE_DEVIATION_BPS: i128 = 5_000;
 const TVL_DRAIN_BPS: i128 = 2_000;
 /// 6-hour rolling window in seconds.
 const VELOCITY_WINDOW_SECS: u64 = 6 * 60 * 60;
+/// 48-hour oracle heartbeat interval.
+const ORACLE_HEARTBEAT_INTERVAL_SECS: u64 = 48 * 60 * 60;
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 
@@ -41,6 +43,12 @@ pub enum CircuitBreakerKey {
     VelocityAccumulator,
     /// Whether the contract is in SoftPause due to a velocity-limit breach.
     SoftPaused,
+    /// Last oracle heartbeat timestamp.
+    OracleLastHeartbeat,
+    /// Whether oracle is frozen due to no heartbeat.
+    OracleFrozenDueToNoHeartbeat,
+    /// Manual exchange rate set by DAO.
+    ManualExchangeRate,
 }
 
 // ── Oracle Price Guard (Issue #312) ───────────────────────────────────────────
@@ -51,6 +59,9 @@ pub enum CircuitBreakerKey {
 /// When the guard is tripped the caller should prevent any price-dependent
 /// operations until `confirm_oracle_price` is called by the sanity oracle.
 pub fn record_oracle_price(env: &Env, new_price: i128) -> bool {
+    // Ping the heartbeat on price update
+    ping_oracle_heartbeat(env);
+
     let last: i128 = env
         .storage()
         .instance()
@@ -110,6 +121,10 @@ pub fn is_oracle_frozen(env: &Env) -> bool {
     env.storage()
         .instance()
         .get(&CircuitBreakerKey::OracleFrozen)
+        .unwrap_or(false) ||
+    env.storage()
+        .instance()
+        .get(&CircuitBreakerKey::OracleFrozenDueToNoHeartbeat)
         .unwrap_or(false)
 }
 
@@ -119,6 +134,54 @@ pub fn set_sanity_oracle(env: &Env, sanity_oracle: &Address) {
     env.storage()
         .instance()
         .set(&CircuitBreakerKey::SanityOracle, sanity_oracle);
+}
+
+// ── Oracle Heartbeat and Manual Revert (Emergency Manual Revert for Oracle Freeze) ───────────────────────────────────────────
+
+/// Ping the oracle heartbeat, resetting the freeze if active.
+pub fn ping_oracle_heartbeat(env: &Env) {
+    let now = env.ledger().timestamp();
+    env.storage()
+        .instance()
+        .set(&CircuitBreakerKey::OracleLastHeartbeat, &now);
+    env.storage()
+        .instance()
+        .set(&CircuitBreakerKey::OracleFrozenDueToNoHeartbeat, &false);
+}
+
+/// Check if oracle heartbeat is still valid. If not, freeze.
+pub fn check_oracle_heartbeat(env: &Env) -> bool {
+    let last: u64 = env
+        .storage()
+        .instance()
+        .get(&CircuitBreakerKey::OracleLastHeartbeat)
+        .unwrap_or(0);
+    let current = env.ledger().timestamp();
+    if current.saturating_sub(last) > ORACLE_HEARTBEAT_INTERVAL_SECS {
+        env.storage()
+            .instance()
+            .set(&CircuitBreakerKey::OracleFrozenDueToNoHeartbeat, &true);
+        false
+    } else {
+        true
+    }
+}
+
+/// Set manual exchange rate via DAO vote, clearing the freeze.
+pub fn set_manual_exchange_rate(env: &Env, rate: i128) {
+    env.storage()
+        .instance()
+        .set(&CircuitBreakerKey::ManualExchangeRate, &rate);
+    env.storage()
+        .instance()
+        .set(&CircuitBreakerKey::OracleFrozenDueToNoHeartbeat, &false);
+}
+
+/// Get the manual exchange rate if set.
+pub fn get_manual_exchange_rate(env: &Env) -> Option<i128> {
+    env.storage()
+        .instance()
+        .get(&CircuitBreakerKey::ManualExchangeRate)
 }
 
 // ── TVL Velocity Limit (Issue #311) ───────────────────────────────────────────

--- a/contracts/grant_stream/src/governance.rs
+++ b/contracts/grant_stream/src/governance.rs
@@ -25,6 +25,13 @@ pub enum ProposalStatus {
     Challenged,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum ProposalType {
+    General,
+    SetManualExchangeRate(i128),
+}
+
 #[derive(Clone, Debug)]
 #[contracttype]
 pub struct Proposal {
@@ -41,6 +48,8 @@ pub struct Proposal {
     pub stake_returned: bool,
     pub is_optimistic: bool,
     pub challenge_deadline: u64,
+    pub proposal_type: ProposalType,
+    pub created_at: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -279,9 +288,11 @@ impl GovernanceContract {
             yes_votes: 0,
             no_votes: 0,
             total_voting_power: 0,
-            created_at: now,
             stake_amount,
             stake_returned: false,
+            is_optimistic: false,
+            challenge_deadline: 0,
+            proposal_type: ProposalType::General,
         };
 
         env.storage().instance().set(&GovernanceDataKey::Proposal(proposal_id), &proposal);
@@ -331,11 +342,12 @@ impl GovernanceContract {
             yes_votes: 0,
             no_votes: 0,
             total_voting_power: 0,
-            created_at: now,
             stake_amount,
             stake_returned: false,
             is_optimistic: true,
             challenge_deadline,
+            proposal_type: ProposalType::General,
+            created_at: now,
         };
 
         env.storage().instance().set(&GovernanceDataKey::Proposal(proposal_id), &proposal);
@@ -345,6 +357,58 @@ impl GovernanceContract {
         env.events().publish(
             (symbol_short!("opti_new"), proposal_id, proposer),
             (amount, challenge_deadline),
+        );
+
+        Ok(proposal_id)
+    }
+
+    pub fn create_set_manual_exchange_rate_proposal(
+        env: Env,
+        proposer: Address,
+        rate: i128,
+        voting_period: u64,
+    ) -> Result<u64, GovernanceError> {
+        proposer.require_auth();
+
+        let stake_token = Self::get_stake_token(&env)?;
+        let stake_amount = Self::get_proposal_stake_amount(&env)?;
+        let token_client = token::Client::new(&env, &stake_token);
+        token_client.transfer(&proposer, &env.current_contract_address(), &stake_amount);
+
+        let now = env.ledger().timestamp();
+        let voting_deadline = now.checked_add(voting_period).ok_or(GovernanceError::MathOverflow)?;
+
+        let mut proposal_ids = Self::get_proposal_ids(&env)?;
+        let proposal_id = if proposal_ids.is_empty() { 0 } else { proposal_ids.get(proposal_ids.len() - 1).unwrap() + 1 };
+
+        let title = String::from_str(&env, "Set Manual Exchange Rate");
+        let description = String::from_str(&env, &format!("Set manual exchange rate to {}", rate));
+
+        let proposal = Proposal {
+            id: proposal_id,
+            proposer: proposer.clone(),
+            title,
+            description,
+            voting_deadline,
+            status: ProposalStatus::Active,
+            yes_votes: 0,
+            no_votes: 0,
+            total_voting_power: 0,
+            stake_amount,
+            stake_returned: false,
+            is_optimistic: false,
+            challenge_deadline: 0,
+            proposal_type: ProposalType::SetManualExchangeRate(rate),
+            created_at: now,
+        };
+
+        env.storage().instance().set(&GovernanceDataKey::Proposal(proposal_id), &proposal);
+        proposal_ids.push_back(proposal_id);
+        env.storage().instance().set(&GovernanceDataKey::ProposalIds, &proposal_ids);
+
+        env.events().publish(
+            (symbol_short!("prop_new"), proposal_id, proposer.clone()),
+            (proposer, voting_deadline),
         );
 
         Ok(proposal_id)
@@ -530,7 +594,14 @@ impl GovernanceContract {
         }
 
         let total_votes = proposal.yes_votes.checked_add(proposal.no_votes).unwrap_or(0);
-        if total_votes == 0 || proposal.yes_votes < voting_threshold {
+        let required_threshold = match proposal.proposal_type {
+            ProposalType::SetManualExchangeRate(_) => {
+                // 90% majority required
+                proposal.total_voting_power * 90 / 100
+            }
+            _ => voting_threshold,
+        };
+        if total_votes == 0 || proposal.yes_votes < required_threshold {
             proposal.status = ProposalStatus::Rejected;
             env.storage().instance().set(&GovernanceDataKey::Proposal(proposal_id), &proposal);
             return Err(GovernanceError::ThresholdNotMet);
@@ -538,6 +609,14 @@ impl GovernanceContract {
 
         proposal.status = ProposalStatus::Executed;
         env.storage().instance().set(&GovernanceDataKey::Proposal(proposal_id), &proposal);
+
+        // Execute the proposal action
+        match proposal.proposal_type {
+            ProposalType::SetManualExchangeRate(rate) => {
+                super::circuit_breakers::set_manual_exchange_rate(&env, rate);
+            }
+            _ => {}
+        }
 
         env.events().publish(
             (symbol_short!("prop_exec"), proposal_id),

--- a/contracts/grant_stream/src/lib.rs
+++ b/contracts/grant_stream/src/lib.rs
@@ -394,6 +394,11 @@ impl GrantStreamContract {
             return Err(Error::SoftPaused);
         }
 
+        // Emergency Manual Revert: reject withdrawals if oracle is frozen.
+        if circuit_breakers::is_oracle_frozen(&env) {
+            return Err(Error::OracleFrozen);
+        }
+
         settle_grant(&mut grant, env.ledger().timestamp())?;
 
         if grant.requires_legal_signature && !grant.is_legal_signed {

--- a/contracts/grant_stream/src/optimized.rs
+++ b/contracts/grant_stream/src/optimized.rs
@@ -71,6 +71,8 @@ pub enum Error {
     InvalidState = 8,
     MathOverflow = 9,
     InvalidStatusTransition = 10, // New error for invalid status transitions
+    SoftPaused = 11,
+    OracleFrozen = 12,
 }
 
 pub fn read_admin(env: &Env) -> Result<Address, Error> {


### PR DESCRIPTION
closes #215
- Add oracle heartbeat mechanism with 48-hour timeout
- Freeze price-dependent operations if no heartbeat for 48 hours
- Add DAO proposal type for setting manual exchange rate with 90% majority
- Allow withdrawals to resume after manual rate is set via governance