### PR TITLE
Add milestone submission anti-spam deposit.

### DIFF
--- a/contracts/grant_stream/src/lib.rs
+++ b/contracts/grant_stream/src/lib.rs
@@ -13,6 +13,7 @@ pub const SCALING_FACTOR: i128 = 10_000_000; // 1e7
 pub const SEP38_STALENESS_SECONDS: u64 = 5 * 60;
 const XLM_DECIMALS: u32 = 7;
 const RENT_RESERVE_XLM: i128 = 5 * 10i128.pow(XLM_DECIMALS);
+const MILESTONE_SUBMISSION_DEPOSIT_XLM: i128 = 100_000; // 0.01 XLM (stroops)
 // Minimum claimable balance required before a withdrawal is permitted (1 USDC in 7-decimal units)
 pub const MIN_WITHDRAWAL: i128 = 10_000_000;
 const RATE_INCREASE_TIMELOCK_SECS: u64 = 48 * 60 * 60;
@@ -175,6 +176,8 @@ pub enum GrantStreamError {
     OracleFrozen = 20,
     RentPreservationMode = 21,
     InvalidTimestamp = 22,
+    InvalidNonce = 23,
+    SubmissionDepositNotFound = 24,
 }
 
 pub type Error = GrantStreamError;
@@ -334,6 +337,18 @@ fn write_expected_milestone_nonce(env: &Env, grant_id: u64, next_nonce: u64) {
     env.storage()
         .instance()
         .set(&DataKey::MilestoneSubmitNonce(grant_id), &next_nonce);
+}
+
+fn set_milestone_submission_deposit(env: &Env, grant_id: u64, milestone_index: u32, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::MilestoneSubmissionDeposit(grant_id, milestone_index), &amount);
+}
+
+fn get_milestone_submission_deposit(env: &Env, grant_id: u64, milestone_index: u32) -> Option<i128> {
+    env.storage()
+        .instance()
+        .get(&DataKey::MilestoneSubmissionDeposit(grant_id, milestone_index))
 }
 
 fn total_allocated_funds(env: &Env) -> Result<i128, Error> {
@@ -1571,7 +1586,21 @@ impl GrantStreamContract {
             return Err(Error::InvalidNonce);
         }
 
+        let native_token_addr: Address = env.storage().instance().get(&StorageKey::NativeToken).ok_or(Error::NotInitialized)?;
+        let native_client = token::Client::new(&env, &native_token_addr);
+        native_client.transfer(
+            &grant.recipient,
+            &env.current_contract_address(),
+            &MILESTONE_SUBMISSION_DEPOSIT_XLM,
+        );
+
         env.storage().persistent().set(&milestone_key, &proof);
+        set_milestone_submission_deposit(
+            &env,
+            grant_id,
+            milestone_index,
+            MILESTONE_SUBMISSION_DEPOSIT_XLM,
+        );
 
         let next_nonce = nonce.checked_add(1).ok_or(Error::MathOverflow)?;
         write_expected_milestone_nonce(&env, grant_id, next_nonce);
@@ -1581,6 +1610,52 @@ impl GrantStreamContract {
             (grant_id, milestone_index, nonce),
         );
 
+        Ok(())
+    }
+
+    /// Admin-only: approve a milestone submission and refund its anti-spam deposit.
+    pub fn approve_milestone_submission(
+        env: Env,
+        grant_id: u64,
+        milestone_index: u32,
+    ) -> Result<(), Error> {
+        require_admin_auth(&env)?;
+        let grant = read_grant(&env, grant_id)?;
+        let deposit = get_milestone_submission_deposit(&env, grant_id, milestone_index)
+            .ok_or(Error::SubmissionDepositNotFound)?;
+        let native_token_addr: Address = env.storage().instance().get(&StorageKey::NativeToken).ok_or(Error::NotInitialized)?;
+        let native_client = token::Client::new(&env, &native_token_addr);
+        native_client.transfer(&env.current_contract_address(), &grant.recipient, &deposit);
+        env.storage()
+            .instance()
+            .remove(&DataKey::MilestoneSubmissionDeposit(grant_id, milestone_index));
+        env.events().publish(
+            (symbol_short!("mil_depr"),),
+            (grant_id, milestone_index, deposit),
+        );
+        Ok(())
+    }
+
+    /// Admin-only: slash a fraudulent milestone submission deposit to treasury.
+    pub fn slash_milestone_submission_deposit(
+        env: Env,
+        grant_id: u64,
+        milestone_index: u32,
+    ) -> Result<(), Error> {
+        require_admin_auth(&env)?;
+        let deposit = get_milestone_submission_deposit(&env, grant_id, milestone_index)
+            .ok_or(Error::SubmissionDepositNotFound)?;
+        let treasury = read_treasury(&env)?;
+        let native_token_addr: Address = env.storage().instance().get(&StorageKey::NativeToken).ok_or(Error::NotInitialized)?;
+        let native_client = token::Client::new(&env, &native_token_addr);
+        native_client.transfer(&env.current_contract_address(), &treasury, &deposit);
+        env.storage()
+            .instance()
+            .remove(&DataKey::MilestoneSubmissionDeposit(grant_id, milestone_index));
+        env.events().publish(
+            (symbol_short!("mil_deps"),),
+            (grant_id, milestone_index, deposit),
+        );
         Ok(())
     }
 

--- a/contracts/grant_stream/src/storage_keys.rs
+++ b/contracts/grant_stream/src/storage_keys.rs
@@ -47,6 +47,8 @@ pub enum StorageKey {
     Milestone(u64, u32),
     /// Expected monotonic nonce for off-chain milestone proof submission
     MilestoneSubmitNonce(u64),
+    /// Escrowed anti-spam submission deposit keyed by (grant_id, milestone_index)
+    MilestoneSubmissionDeposit(u64, u32),
     /// Grant streaming metadata and configuration
     GrantStreamConfig(u64),
     /// Grant legal compliance data (hashes, signatures)
@@ -278,6 +280,7 @@ impl StorageKey {
             StorageKey::Grant(_)
             | StorageKey::Milestone(_, _)
             | StorageKey::MilestoneSubmitNonce(_)
+            | StorageKey::MilestoneSubmissionDeposit(_, _)
             | StorageKey::GrantStreamConfig(_)
             | StorageKey::GrantLegalData(_)
             | StorageKey::GrantValidatorData(_)
@@ -405,6 +408,8 @@ impl StorageKey {
             
             StorageKey::Grant(_) => "Individual grant data and metadata",
             StorageKey::Milestone(_, _) => "Grant milestone information",
+            StorageKey::MilestoneSubmitNonce(_) => "Expected nonce for milestone proof submission",
+            StorageKey::MilestoneSubmissionDeposit(_, _) => "Escrowed anti-spam deposit for milestone submission",
             StorageKey::GrantStreamConfig(_) => "Grant streaming configuration",
             StorageKey::GrantLegalData(_) => "Grant legal compliance data",
             StorageKey::GrantValidatorData(_) => "Grant validator rewards data",

--- a/contracts/grant_stream/src/test.rs
+++ b/contracts/grant_stream/src/test.rs
@@ -52,6 +52,62 @@ fn test_pipeline() {
 }
 
 #[test]
+fn test_milestone_submission_deposit_refunded_on_approval() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, _grant_token_addr, _treasury, _oracle, native_token_addr, client) = setup_test(&env);
+    let recipient = Address::generate(&env);
+    let native_token = token::Client::new(&env, &native_token_addr);
+    let native_token_admin = token::StellarAssetClient::new(&env, &native_token_addr);
+    let grant_id = 77u64;
+    let deposit = 100_000i128;
+
+    native_token_admin.mint(&recipient, &1_000_000i128);
+    client.create_grant(&grant_id, &recipient, &1_000_000i128, &1_000i128, &0u64, &None, &None);
+
+    let recipient_before = native_token.balance(&recipient);
+    let contract_before = native_token.balance(&client.address);
+    client.submit_milestone_proof(&grant_id, &0u32, &Symbol::new(&env, "m0"), &0u64).unwrap();
+    let recipient_after_submit = native_token.balance(&recipient);
+    let contract_after_submit = native_token.balance(&client.address);
+
+    assert_eq!(recipient_after_submit, recipient_before - deposit);
+    assert_eq!(contract_after_submit, contract_before + deposit);
+
+    client.approve_milestone_submission(&grant_id, &0u32).unwrap();
+    let recipient_after_approval = native_token.balance(&recipient);
+    let contract_after_approval = native_token.balance(&client.address);
+
+    assert_eq!(recipient_after_approval, recipient_before);
+    assert_eq!(contract_after_approval, contract_before);
+}
+
+#[test]
+fn test_milestone_submission_deposit_slashed_to_treasury() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, _grant_token_addr, treasury, _oracle, native_token_addr, client) = setup_test(&env);
+    let recipient = Address::generate(&env);
+    let native_token = token::Client::new(&env, &native_token_addr);
+    let native_token_admin = token::StellarAssetClient::new(&env, &native_token_addr);
+    let grant_id = 78u64;
+    let deposit = 100_000i128;
+
+    native_token_admin.mint(&recipient, &1_000_000i128);
+    client.create_grant(&grant_id, &recipient, &1_000_000i128, &1_000i128, &0u64, &None, &None);
+
+    let treasury_before = native_token.balance(&treasury);
+    let contract_before = native_token.balance(&client.address);
+    client.submit_milestone_proof(&grant_id, &0u32, &Symbol::new(&env, "m1"), &0u64).unwrap();
+    client.slash_milestone_submission_deposit(&grant_id, &0u32).unwrap();
+
+    let treasury_after = native_token.balance(&treasury);
+    let contract_after = native_token.balance(&client.address);
+    assert_eq!(treasury_after, treasury_before + deposit);
+    assert_eq!(contract_after, contract_before);
+}
+
+#[test]
 fn test_is_active_grantee_basic_functionality() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Require grantees to escrow a small XLM deposit on milestone proof submission, refund it on approval, and slash it to treasury when fraudulent submissions are confirmed.

closes #340