### PR TITLE
Add milestone-expiry auto-cancellation for abandoned grants.

### DIFF
--- a/contracts/grant_stream/src/multi_threshold.rs
+++ b/contracts/grant_stream/src/multi_threshold.rs
@@ -13,6 +13,7 @@
 /// Issue #336: Optimized signature verification and gas buffer for complex multi-sig transactions
 
 use soroban_sdk::{symbol_short, Address, Bytes, Env, Vec, xdr::ToXdr};
+use crate::GrantStreamError as Error;
 
 // ── Thresholds ────────────────────────────────────────────────────────────────
 

--- a/contracts/grant_stream/src/multi_token.rs
+++ b/contracts/grant_stream/src/multi_token.rs
@@ -6,8 +6,8 @@ use soroban_sdk::{
 };
 
 use super::optimized::{
-    GrantContract, Grant, Error, DataKey, read_grant, write_grant, settle_grant,
-    STATUS_ACTIVE, STATUS_PAUSED, STATUS_COMPLETED, STATUS_CANCELLED,
+    Grant, Error, DataKey,
+    STATUS_ACTIVE, STATUS_PAUSED, STATUS_COMPLETED,
     has_status, set_status, clear_status, read_admin, require_admin_auth,
 };
 

--- a/contracts/grant_stream/src/optimized.rs
+++ b/contracts/grant_stream/src/optimized.rs
@@ -115,6 +115,44 @@ fn clear_milestone_evidence(env: &Env, grant_id: u64) {
     env.storage().instance().remove(&DataKey::MilestoneEvidence(grant_id));
 }
 
+fn maybe_auto_cancel_milestone_expiry(
+    env: &Env,
+    grant_id: u64,
+    grant: &mut Grant,
+) -> Result<bool, Error> {
+    if !has_status(grant.status_mask, STATUS_MILESTONE_BASED) {
+        return Ok(false);
+    }
+    if has_status(grant.status_mask, STATUS_CANCELLED)
+        || has_status(grant.status_mask, STATUS_COMPLETED)
+        || has_status(grant.status_mask, STATUS_RAGE_QUIT)
+    {
+        return Ok(false);
+    }
+
+    let now = env.ledger().timestamp();
+    if grant.milestone_deadline == 0 || now <= grant.milestone_deadline || grant.milestone_met {
+        return Ok(false);
+    }
+
+    let cancel_settle_ts = if grant.last_update_ts < grant.milestone_deadline {
+        grant.milestone_deadline
+    } else {
+        grant.last_update_ts
+    };
+    settle_grant(grant, cancel_settle_ts)?;
+    grant.status_mask = set_status(grant.status_mask, STATUS_CANCELLED);
+    grant.status_mask = clear_status(grant.status_mask, STATUS_ACTIVE);
+    grant.status_mask = clear_status(grant.status_mask, STATUS_PAUSED);
+    grant.flow_rate = 0;
+    write_grant(env, grant_id, grant);
+    env.events().publish(
+        (symbol_short!("milexpir"), grant_id),
+        (grant.milestone_deadline, cancel_settle_ts),
+    );
+    Ok(true)
+}
+
 pub fn validate_status_transition(current_mask: u32, new_mask: u32) -> Result<(), Error> {
     if has_status(current_mask, STATUS_COMPLETED) || has_status(current_mask, STATUS_CANCELLED) {
         return Err(Error::InvalidStatusTransition);
@@ -364,7 +402,8 @@ impl GrantContract {
     }
 
     pub fn get_grant(env: Env, grant_id: u64) -> Result<Grant, Error> {
-        let grant = read_grant(&env, grant_id)?;
+        let mut grant = read_grant(&env, grant_id)?;
+        let _ = maybe_auto_cancel_milestone_expiry(&env, grant_id, &mut grant)?;
         preview_grant_at_now(&env, &grant)
     }
 
@@ -398,7 +437,8 @@ impl GrantContract {
     }
 
     pub fn claimable(env: Env, grant_id: u64) -> Result<i128, Error> {
-        let grant = read_grant(&env, grant_id)?;
+        let mut grant = read_grant(&env, grant_id)?;
+        let _ = maybe_auto_cancel_milestone_expiry(&env, grant_id, &mut grant)?;
         let preview = preview_grant_at_now(&env, &grant)?;
         Ok(preview.claimable)
     }
@@ -409,6 +449,7 @@ impl GrantContract {
         }
 
         let mut grant = read_grant(&env, grant_id)?;
+        let _ = maybe_auto_cancel_milestone_expiry(&env, grant_id, &mut grant)?;
 
         // Can only withdraw from active grants
         if !has_status(grant.status_mask, STATUS_ACTIVE) {
@@ -444,6 +485,13 @@ impl GrantContract {
 
         write_grant(&env, grant_id, &grant);
         Ok(())
+    }
+
+    /// Auto-cancel milestone-based grants that missed deadline without approval.
+    /// Returns `true` when cancellation was applied, `false` otherwise.
+    pub fn process_milestone_expiry(env: Env, grant_id: u64) -> Result<bool, Error> {
+        let mut grant = read_grant(&env, grant_id)?;
+        maybe_auto_cancel_milestone_expiry(&env, grant_id, &mut grant)
     }
 
     pub fn update_rate(env: Env, grant_id: u64, new_rate: i128) -> Result<(), Error> {

--- a/contracts/grant_stream/src/self_terminate.rs
+++ b/contracts/grant_stream/src/self_terminate.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{
 };
 
 use super::optimized::{
-    GrantContract, Grant, Error, DataKey, read_grant, write_grant, settle_grant,
+    GrantContract, Grant, Error, read_grant, write_grant, settle_grant,
     STATUS_ACTIVE, STATUS_PAUSED, STATUS_COMPLETED, STATUS_CANCELLED,
     has_status, set_status, clear_status, read_admin,
 };

--- a/contracts/grant_stream/src/test_optimized.rs
+++ b/contracts/grant_stream/src/test_optimized.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use soroban_sdk::{Address, testutils::{Ledger, LedgerInfo}};
-use super::optimized::{GrantContract, STATUS_ACTIVE, STATUS_PAUSED, STATUS_COMPLETED, STATUS_CANCELLED};
+use super::optimized::{GrantContract, STATUS_ACTIVE, STATUS_PAUSED, STATUS_COMPLETED, STATUS_CANCELLED, STATUS_MILESTONE_BASED};
 
 #[test]
 fn test_bitwise_status_operations() {
@@ -228,6 +228,87 @@ fn test_milestone_evidence_anchor_required() {
     GrantContract::set_milestone_deadline(&ledger, &contract_id, 2u64, 1_800_000_000).unwrap();
     let result = GrantContract::mark_milestone_met(&ledger, &contract_id, 2u64);
     assert!(result.is_err(), "milestone approval must fail after deadline reset without new evidence");
+}
+
+#[test]
+fn test_milestone_expiry_auto_cancels_abandoned_grant() {
+    let ledger_info = LedgerInfo {
+        protocol_version: 20,
+        sequence_number: 12345,
+        timestamp: 1_620_000_000,
+        network_id: 1,
+        base_reserve: 10,
+        min_persistent_entry_fee: 100,
+        min_temp_entry_fee: 100,
+    };
+
+    let ledger = Ledger::with_info(&ledger_info);
+    let admin = Address::from_public_key(&[21; 32]);
+    let recipient = Address::from_public_key(&[22; 32]);
+    let contract_id = ledger.contract_id();
+
+    GrantContract::initialize(&ledger, &contract_id, admin).unwrap();
+    GrantContract::create_grant(
+        &ledger,
+        &contract_id,
+        21u64,
+        recipient,
+        1000000i128,
+        100i128,
+        STATUS_ACTIVE | STATUS_MILESTONE_BASED,
+    )
+    .unwrap();
+    GrantContract::set_milestone_deadline(&ledger, &contract_id, 21u64, 1_610_000_000).unwrap();
+
+    let cancelled = GrantContract::process_milestone_expiry(&ledger, &contract_id, 21u64).unwrap();
+    assert!(cancelled, "expired unapproved milestone grant should auto-cancel");
+    assert!(GrantContract::is_grant_cancelled(&ledger, &contract_id, 21u64).unwrap());
+}
+
+#[test]
+fn test_milestone_expiry_does_not_cancel_when_met() {
+    let ledger_info = LedgerInfo {
+        protocol_version: 20,
+        sequence_number: 12345,
+        timestamp: 1_620_000_000,
+        network_id: 1,
+        base_reserve: 10,
+        min_persistent_entry_fee: 100,
+        min_temp_entry_fee: 100,
+    };
+
+    let ledger = Ledger::with_info(&ledger_info);
+    let admin = Address::from_public_key(&[31; 32]);
+    let recipient = Address::from_public_key(&[32; 32]);
+    let contract_id = ledger.contract_id();
+
+    GrantContract::initialize(&ledger, &contract_id, admin.clone()).unwrap();
+    GrantContract::create_grant(
+        &ledger,
+        &contract_id,
+        31u64,
+        recipient.clone(),
+        1000000i128,
+        100i128,
+        STATUS_ACTIVE | STATUS_MILESTONE_BASED,
+    )
+    .unwrap();
+    GrantContract::set_milestone_deadline(&ledger, &contract_id, 31u64, 1_610_000_000).unwrap();
+
+    ledger.set_source_account(&recipient);
+    GrantContract::submit_milestone_evidence(
+        &ledger,
+        &contract_id,
+        31u64,
+        "QmMetEvidence".to_string(),
+    )
+    .unwrap();
+    ledger.set_source_account(&admin);
+    GrantContract::mark_milestone_met(&ledger, &contract_id, 31u64).unwrap();
+
+    let cancelled = GrantContract::process_milestone_expiry(&ledger, &contract_id, 31u64).unwrap();
+    assert!(!cancelled, "met milestone must not auto-cancel");
+    assert!(!GrantContract::is_grant_cancelled(&ledger, &contract_id, 31u64).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
Automatically cancel milestone-based grants when deadlines pass without milestone approval, and cover the behavior with focused optimized-contract tests for cancelled and milestone-met scenarios.
closes #406